### PR TITLE
updated to compile against more recent opencl headers

### DIFF
--- a/cmake/Modules/FindOpenCL.cmake
+++ b/cmake/Modules/FindOpenCL.cmake
@@ -150,7 +150,7 @@ find_path(CL_HPP
 # Testing NOTE: you may need to delete the build directory to remove any cmake cache
 # then recreate it for changes here to actually show up as expected.
    CL/clxxasdf.hpp OpenCL/clxxasdf.hpp
-   CL/cl.hpp OpenCL/cl.hpp
+   CL/opencl.hpp OpenCL/cl.hpp
   PATHS
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT

--- a/include/clenabled/GRCLBase.h
+++ b/include/clenabled/GRCLBase.h
@@ -19,10 +19,13 @@
 #define CL_VERSION_2_2
 #define CL_TARGET_OPENCL_VERSION 220
 
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_TARGET_OPENCL_VERSION 220
+
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/cl.hpp>
 #else
-#include <CL/cl.hpp>
+#include <CL/opencl.hpp>
 #endif
 
 #include "clSComplex.h"

--- a/lib/GRCLBase.cpp
+++ b/lib/GRCLBase.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
 #include <clenabled/GRCLBase.h>
 
 namespace gr {

--- a/lib/clFFT_impl.cc
+++ b/lib/clFFT_impl.cc
@@ -22,6 +22,8 @@
 #include "config.h"
 #endif
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
+
 #include <gnuradio/io_signature.h>
 #include "clFFT_impl.h"
 #include "window.h"

--- a/lib/clPolyphaseChannelizer_impl.cc
+++ b/lib/clPolyphaseChannelizer_impl.cc
@@ -22,6 +22,8 @@
 #include "config.h"
 #endif
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
+
 #include <gnuradio/io_signature.h>
 #include "clPolyphaseChannelizer_impl.h"
 

--- a/lib/clXCorrelate_impl.cc
+++ b/lib/clXCorrelate_impl.cc
@@ -679,6 +679,8 @@
 #include "config.h"
 #endif
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
+
 #include <gnuradio/io_signature.h>
 #include "clXCorrelate_impl.h"
 

--- a/lib/clXEngine_impl.cc
+++ b/lib/clXEngine_impl.cc
@@ -679,6 +679,7 @@
 #include "config.h"
 #endif
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
 #include <gnuradio/io_signature.h>
 #include "clXEngine_impl.h"
 #include <volk/volk.h>

--- a/lib/clview.cc
+++ b/lib/clview.cc
@@ -8,10 +8,13 @@
 // #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #define CL_VERSION_1_2
 
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_TARGET_OPENCL_VERSION 200
+
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/cl.hpp>
 #else
-#include <CL/cl.hpp>
+#include <CL/opencl.hpp>
 #endif
 
 #include <iostream>

--- a/lib/clxcorrelate_fft_vcf_impl.cc
+++ b/lib/clxcorrelate_fft_vcf_impl.cc
@@ -679,6 +679,7 @@
 #include "config.h"
 #endif
 
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
 #include <gnuradio/io_signature.h>
 #include "clxcorrelate_fft_vcf_impl.h"
 


### PR DESCRIPTION
this commit should fix #4

i deliberately added `#defines` to mark which files need updating to the newer API

i managed to compile this on a devuan host, against the following package:

opencl-clhpp-headers 3.0~2.0.13-1 - which seems to be from `khronos-opencl-clhpp`